### PR TITLE
[AUTH-003] 登出 API

### DIFF
--- a/src/main/java/com/example/petel/controller/AuthController.java
+++ b/src/main/java/com/example/petel/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.example.petel.exception.InvalidInputException;
 import com.example.petel.exception.JwtProcessingException;
 import com.example.petel.service.AUTH001Svc;
 import com.example.petel.service.AUTH002Svc;
+import com.example.petel.service.AUTH003Svc;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +15,16 @@ import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 @CrossOrigin("http://localhost:4200")
 public class AuthController extends BaseController{
     /** AUTH001 Service */
     private final AUTH001Svc auth001Svc;
     /** AUTH002 Service */
     private final AUTH002Svc auth002Svc;
+    /** AUTH003 Service */
+    private final AUTH003Svc auth003Svc;
 
     /**
      * 註冊
@@ -54,5 +57,15 @@ public class AuthController extends BaseController{
             throws InvalidInputException, JwtProcessingException {
         handleValidForDto(errors);
         return auth002Svc.login(req, resp);
+    }
+
+    /**
+     * 登出
+     * @param resp
+     * @return
+     */
+    @PostMapping("/logout")
+    public Res<Object> logout(HttpServletResponse resp) {
+        return auth003Svc.logout(resp);
     }
 }

--- a/src/main/java/com/example/petel/service/AUTH001Svc.java
+++ b/src/main/java/com/example/petel/service/AUTH001Svc.java
@@ -7,5 +7,5 @@ import com.example.petel.dto.Res;
 import com.example.petel.exception.InsertFailException;
 
 public interface AUTH001Svc {
-    public Res<AUTH001Tranrs> register(Req<AUTH001Tranrq> req) throws InsertFailException;
+    Res<AUTH001Tranrs> register(Req<AUTH001Tranrq> req) throws InsertFailException;
 }

--- a/src/main/java/com/example/petel/service/AUTH002Svc.java
+++ b/src/main/java/com/example/petel/service/AUTH002Svc.java
@@ -10,7 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public interface AUTH002Svc {
 
-    public Res<AUTH002Tranrs> login(Req<AUTH002Tranrq> req, HttpServletResponse resp)
+    Res<AUTH002Tranrs> login(Req<AUTH002Tranrq> req, HttpServletResponse resp)
             throws InvalidInputException, JwtProcessingException;
 
 }

--- a/src/main/java/com/example/petel/service/AUTH003Svc.java
+++ b/src/main/java/com/example/petel/service/AUTH003Svc.java
@@ -1,4 +1,9 @@
 package com.example.petel.service;
 
-public class AUTH003Svc {
+import com.example.petel.dto.Res;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface AUTH003Svc {
+
+    Res<Object> logout(HttpServletResponse resp);
 }

--- a/src/main/java/com/example/petel/service/AUTH003Svc.java
+++ b/src/main/java/com/example/petel/service/AUTH003Svc.java
@@ -1,0 +1,4 @@
+package com.example.petel.service;
+
+public class AUTH003Svc {
+}

--- a/src/main/java/com/example/petel/service/impl/AUTH003SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/AUTH003SvcImpl.java
@@ -1,4 +1,65 @@
 package com.example.petel.service.impl;
 
-public class AUTH003SvcImpl {
+import com.example.petel.dto.Res;
+import com.example.petel.dto.ResMwHeader;
+import com.example.petel.model.ReturnCodeAndDescEnum;
+import com.example.petel.model.jwt.JwtUtil;
+import com.example.petel.repository.AccountsRepository;
+import com.example.petel.service.AUTH003Svc;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AUTH003SvcImpl implements AUTH003Svc {
+
+    /** AccountsRepository */
+    private final AccountsRepository accountsRepo;
+    /** PasswordEncoder */
+    private final PasswordEncoder passwordEncoder;
+    /** JwtUtil */
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 登出
+     * @param resp HttpServletResponse
+     * @return Res<Object>
+     */
+    @Override
+    public Res<Object> logout(HttpServletResponse resp) {
+        log.info("---- [AUTH-003] 登出 ----");
+
+        // 清除 access Token
+        ResponseCookie clearAccess = ResponseCookie.from("access_token", "")
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        // 清除 Refresh Token
+        ResponseCookie clearRefresh = ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("Strict")
+                .path("/auth")
+                .maxAge(0)
+                .build();
+
+        resp.addHeader(HttpHeaders.SET_COOKIE, clearAccess.toString());
+        resp.addHeader(HttpHeaders.SET_COOKIE, clearRefresh.toString());
+
+        log.info("[AUTH-003] 登出成功，Cookie 已清除");
+        return new Res<>(
+                new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS),
+                null
+        );
+    }
 }

--- a/src/main/java/com/example/petel/service/impl/AUTH003SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/AUTH003SvcImpl.java
@@ -1,0 +1,4 @@
+package com.example.petel.service.impl;
+
+public class AUTH003SvcImpl {
+}


### PR DESCRIPTION
## Change
- 新增登出 API

## Test
1. run server
2. application.properties
```
# JWT
jwt.secret=1FhYq@9pR7TjZ4wC8nKm!sQ2vBbN6yXeLdP3uGaH
jwt.access.expiration=900000       
jwt.refresh.expiration=2592000000
```
3. DB 建立 PETEL_ACCOUNTS 表
```
create table PETEL_ACCOUNTS (
  ACCOUNT_ID    number          generated by default as identity primary key,
  EMAIL         varchar2(255)   not null unique,
  PASSWORD      varchar2(255)   not null,
  ROLE          varchar2(20)    not null,
  STATUS        varchar2(20)    not null
);
```
4. call `POST`  http://localhost:8080/auth/register
Body:
```
{
    "MWHEADER": {
        "MSGID": "AUTH-001"
    },
    "TRANRQ": {
        "email": "test@example.com",
        "password": "123456",
        "role": "member"
    }
}
```
5. call `POST` http://localhost:8080/auth/login
```
{
    "MWHEADER": {
        "MSGID": "AUTH-002"
    },
    "TRANRQ": {
        "email": "test@example.com",
        "password": "123456",
        "role": "member"
    }
}
```
6. call `POST` http://localhost:8080/auth/logout

## Expected Result
登出成功：
<img width="769" height="697" alt="image" src="https://github.com/user-attachments/assets/38889b6d-e979-4146-93cf-15ea869f7640" />
