### PR TITLE
[USER-001] 新增會員資訊

### DIFF
--- a/src/main/java/com/example/petel/controller/UserController.java
+++ b/src/main/java/com/example/petel/controller/UserController.java
@@ -1,0 +1,43 @@
+package com.example.petel.controller;
+
+import com.example.petel.controller.advice.BaseController;
+import com.example.petel.dto.Req;
+import com.example.petel.dto.Res;
+import com.example.petel.dto.USER001Tranrq;
+import com.example.petel.dto.USER001Tranrs;
+import com.example.petel.exception.InsertFailException;
+import com.example.petel.exception.InvalidInputException;
+import com.example.petel.model.jwt.AccountPrincipal;
+import com.example.petel.service.USER001Svc;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+@CrossOrigin("http://localhost:4200")
+public class UserController extends BaseController {
+
+    /** USER001Svc */
+    private final USER001Svc user001Svc;
+
+    /**
+     * 新增會員資訊
+     * @param authInfo
+     * @param req
+     * @param errors
+     * @return
+     * @throws InsertFailException
+     * @throws InvalidInputException
+     */
+    @PostMapping("/create")
+    public Res<USER001Tranrs> createUser(@AuthenticationPrincipal AccountPrincipal authInfo,
+            @Valid @RequestBody Req<USER001Tranrq> req, Errors errors)
+            throws InsertFailException, InvalidInputException {
+        handleValidForDto(errors);
+        return user001Svc.createUser(authInfo.getAccountId(), req);
+    }
+}

--- a/src/main/java/com/example/petel/dto/USER001Tranrq.java
+++ b/src/main/java/com/example/petel/dto/USER001Tranrq.java
@@ -1,0 +1,41 @@
+package com.example.petel.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class USER001Tranrq implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * name
+     */
+    @JsonProperty("name")
+    @NotBlank(message = "Name 不得為空")
+    private String name;
+
+    /**
+     * phone
+     */
+    @JsonProperty("phone")
+    @Pattern(regexp = "^[0-9+\\-()\\s]{6,20}$", message = "phone 格式不正確")
+    @NotBlank(message = "Name 不得為空")
+    private String phone;
+
+    /**
+     * mediaId
+     */
+    @JsonProperty("mediaId")
+    private String mediaId;
+}

--- a/src/main/java/com/example/petel/dto/USER001Tranrs.java
+++ b/src/main/java/com/example/petel/dto/USER001Tranrs.java
@@ -1,0 +1,48 @@
+package com.example.petel.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class USER001Tranrs implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * user ID
+     */
+    @JsonProperty("id")
+    private String id;
+
+    /**
+     * account ID
+     */
+    @JsonProperty("accountId")
+    private String accountId;
+
+    /**
+     * name
+     */
+    @JsonProperty("name")
+    private String name;
+
+    /**
+     * phone
+     */
+    @JsonProperty("phone")
+    private String phone;
+
+    /**
+     * mediaId
+     */
+    @JsonProperty("mediaId")
+    private String mediaId;
+}

--- a/src/main/java/com/example/petel/entity/UsersEntity.java
+++ b/src/main/java/com/example/petel/entity/UsersEntity.java
@@ -46,7 +46,7 @@ public class UsersEntity {
     /**
      * 頭像媒體 ID
      */
-    @Column(name = "AVATAR_MEDIA_ID")
-    @JsonProperty("avatarMediaId")
-    private String avatarMediaId;
+    @Column(name = "MEDIA_ID")
+    @JsonProperty("mediaId")
+    private String mediaId;
 }

--- a/src/main/java/com/example/petel/repository/UsersRepository.java
+++ b/src/main/java/com/example/petel/repository/UsersRepository.java
@@ -11,7 +11,25 @@ import java.util.Optional;
 @Repository
 public interface UsersRepository extends JpaRepository<UsersEntity, String> {
 
-    /** 用 accountId 查 user */
+    /**
+     * 用 accountId 查 user
+     * @param accountId
+     * @return
+     */
     @Query(value = "SELECT ID FROM PETEL_USERS WHERE ACCOUNT_ID = :accountId", nativeQuery = true)
     String findIdByAccountId(@Param("accountId") String accountId);
+
+    /**
+     * 查目前最大ID
+     * @return
+     */
+    @Query("select max(e.id) from UsersEntity e")
+    String findMaxId();
+
+    /**
+     * 檢查 accountID 是否存在
+     * @param accountId
+     * @return
+     */
+    boolean existsByAccountId(String accountId);
 }

--- a/src/main/java/com/example/petel/service/USER001Svc.java
+++ b/src/main/java/com/example/petel/service/USER001Svc.java
@@ -1,0 +1,13 @@
+package com.example.petel.service;
+
+import com.example.petel.dto.Req;
+import com.example.petel.dto.Res;
+import com.example.petel.dto.USER001Tranrq;
+import com.example.petel.dto.USER001Tranrs;
+import com.example.petel.exception.InsertFailException;
+
+public interface USER001Svc {
+
+    Res<USER001Tranrs> createUser(String accountId, Req<USER001Tranrq> req)
+            throws InsertFailException;
+}

--- a/src/main/java/com/example/petel/service/impl/AUTH006SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/AUTH006SvcImpl.java
@@ -41,25 +41,30 @@ public class AUTH006SvcImpl implements AUTH006Svc {
     @Override
     public Res<AUTH006Tranrs> getInfo(AccountPrincipal authInfo)
             throws JwtProcessingException {
+        log.info("---- [AUTH-006] 取得使用者資訊 ----");
         if (authInfo == null){
+            log.warn("[AUTH-006] 無法取得使用者資訊：authInfo 為 null，回傳 401");
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
 
         String accountId = authInfo.getAccountId();
         String role = authInfo.getRole();
+        log.info("[AUTH-006] 登入使用者資訊：accountId={}, role={}", accountId, role);
 
         String mainId = accountQuerySvc.getIdByRoleAndAccountId(
                 role, accountId
         );
+        log.info("[AUTH-006] 查詢對應主表 ID 成功：mainId={}", mainId);
 
         String email = accountRepo.findEmailById(accountId);
+        log.info("[AUTH-006] 查詢 Email 成功：email={}", email);
 
         AUTH006Tranrs tranrs = new AUTH006Tranrs();
         tranrs.setAccountId(accountId);
         tranrs.setEmail(email);
         tranrs.setRole(role);
         tranrs.setMainId(mainId);
-
+        log.info("[AUTH-006] 取得使用者資訊成功，回傳結果：{}", tranrs);
 
         return new Res<>(new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS), tranrs);
     }

--- a/src/main/java/com/example/petel/service/impl/USER001SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/USER001SvcImpl.java
@@ -1,0 +1,66 @@
+package com.example.petel.service.impl;
+
+import com.example.petel.dto.*;
+import com.example.petel.entity.UsersEntity;
+import com.example.petel.exception.InsertFailException;
+import com.example.petel.model.IdUtil;
+import com.example.petel.model.ReturnCodeAndDescEnum;
+import com.example.petel.repository.UsersRepository;
+import com.example.petel.service.USER001Svc;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class USER001SvcImpl implements USER001Svc {
+
+    /** UsersRepository */
+    private final UsersRepository usersRepo;
+    /** ObjectMapper */
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    @Override
+    public Res<USER001Tranrs> createUser(String accountId, Req<USER001Tranrq> req)
+            throws InsertFailException {
+        log.info("---- [USER-001] 新增會員資訊 ----");
+        log.info("[USER-001] accountId={}, req={}", accountId, req);
+
+        // 檢查 Account ID 是否存在
+        if (usersRepo.existsByAccountId(accountId)) {
+            log.warn("[USER-001] 該帳號已建立會員資訊，accountId={}", accountId);
+            throw new InsertFailException("該帳號已建立會員資訊");
+        }
+
+        String maxId = usersRepo.findMaxId();
+        String userId = IdUtil.generateTableId("U", maxId);
+        log.info("[USER-001] 新會員ID 產生完成 userId={} (maxId={})", userId, maxId);
+
+        USER001Tranrq tranrq = req.getTranrq();
+        UsersEntity entity = new UsersEntity();
+        entity.setId(userId);
+        entity.setAccountId(accountId);
+        entity.setName(tranrq.getName());
+        entity.setPhone(tranrq.getPhone());
+        entity.setMediaId(tranrq.getMediaId());
+
+        try {
+            usersRepo.save(entity);
+            log.info("[USER-001] 新增會員資料成功 userId={}", userId);
+        } catch (Exception e) {
+            log.error("[USER-001] 新增會員資料失敗，原因：{}", e.getMessage(), e);
+            throw new InsertFailException("新增會員資訊失敗");
+        }
+
+        USER001Tranrs tranrs = objectMapper.convertValue(entity, USER001Tranrs.class);
+
+        return new Res<USER001Tranrs>(
+                new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS),
+                tranrs
+        );
+    }
+}


### PR DESCRIPTION
## Change
- 新增會員資訊 API
- 修改 Auth006 的 log

## Info
若到時候要改用 token 拿 用戶資料，可以參考這支 跟 [[AUTH-006] ](https://github.com/JLin056/petel-backend/pull/50)的拿法～
主要是在 Controller 加 `@AuthenticationPrincipal AccountPrincipal authInfo`

## Test
1. application.property
```
# JWT
jwt.secret=1FhYq@9pR7TjZ4wC8nKm!sQ2vBbN6yXeLdP3uGaH
jwt.access.expiration=900000
jwt.refresh.expiration=2592000000
```
2. run server
3. 註冊帳號與登入帳號（若已有帳號，可以跳過註冊 只需登入）
4. call API `POST` http://localhost:8080/user/create
Body:
```
{
    "MWHEADER": {
        "MSGID": "USER-001"
    },
    "TRANRQ": {
        "name": "測試會員資訊",
        "phone": "0944444444",
        "mediaId": "M000000001"
    }
}
```
5. 新增成功後，再 call 一次 API，會發現新增失敗（因為已新增過了）

## Expected Value
- 新增成功
<img width="1118" height="892" alt="image" src="https://github.com/user-attachments/assets/58557c2d-5f7d-4d18-bc57-fe70eb6e62cd" />

- 重複新增
<img width="1124" height="791" alt="image" src="https://github.com/user-attachments/assets/94ed4988-a93a-4948-89b8-b93a92f24b33" />
