### PR TITLE
[USER-002] 修改會員資訊 API

### DIFF
--- a/src/main/java/com/example/petel/controller/UserController.java
+++ b/src/main/java/com/example/petel/controller/UserController.java
@@ -1,14 +1,14 @@
 package com.example.petel.controller;
 
 import com.example.petel.controller.advice.BaseController;
-import com.example.petel.dto.Req;
-import com.example.petel.dto.Res;
-import com.example.petel.dto.USER001Tranrq;
-import com.example.petel.dto.USER001Tranrs;
+import com.example.petel.dto.*;
+import com.example.petel.exception.DataNotFoundException;
 import com.example.petel.exception.InsertFailException;
 import com.example.petel.exception.InvalidInputException;
 import com.example.petel.model.jwt.AccountPrincipal;
 import com.example.petel.service.USER001Svc;
+import com.example.petel.service.USER002Svc;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +23,8 @@ public class UserController extends BaseController {
 
     /** USER001Svc */
     private final USER001Svc user001Svc;
+    /** USER002Svc */
+    private final USER002Svc user002Svc;
 
     /**
      * 新增會員資訊
@@ -39,5 +41,23 @@ public class UserController extends BaseController {
             throws InsertFailException, InvalidInputException {
         handleValidForDto(errors);
         return user001Svc.createUser(authInfo.getAccountId(), req);
+    }
+
+    /**
+     * 更新會怨資訊
+     * @param authInfo
+     * @param req
+     * @param errors
+     * @return
+     * @throws InvalidInputException
+     * @throws DataNotFoundException
+     */
+    @PostMapping("/update")
+    public Res<USER002Tranrs> updateUser(@AuthenticationPrincipal AccountPrincipal authInfo,
+                                         @Valid @RequestBody Req<USER002Tranrq> req,
+                                         Errors errors)
+            throws DataNotFoundException, JsonMappingException, InsertFailException, InvalidInputException {
+        handleValidForDto(errors);
+        return user002Svc.updateUser(authInfo.getAccountId(), req);
     }
 }

--- a/src/main/java/com/example/petel/dto/USER002Tranrq.java
+++ b/src/main/java/com/example/petel/dto/USER002Tranrq.java
@@ -1,5 +1,6 @@
 package com.example.petel.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -11,9 +12,10 @@ import java.io.Serial;
 import java.io.Serializable;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
-public class USER001Tranrq implements Serializable {
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class USER002Tranrq implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
@@ -22,7 +24,6 @@ public class USER001Tranrq implements Serializable {
      * name
      */
     @JsonProperty("name")
-    @NotBlank(message = "Name 不得為空")
     private String name;
 
     /**
@@ -30,7 +31,6 @@ public class USER001Tranrq implements Serializable {
      */
     @JsonProperty("phone")
     @Pattern(regexp = "^[0-9+\\-()\\s]{6,20}$", message = "phone 格式不正確")
-    @NotBlank(message = "phone 不得為空")
     private String phone;
 
     /**

--- a/src/main/java/com/example/petel/dto/USER002Tranrs.java
+++ b/src/main/java/com/example/petel/dto/USER002Tranrs.java
@@ -1,8 +1,6 @@
 package com.example.petel.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,26 +9,35 @@ import java.io.Serial;
 import java.io.Serializable;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
-public class USER001Tranrq implements Serializable {
+@AllArgsConstructor
+public class USER002Tranrs implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
 
     /**
+     * user ID
+     */
+    @JsonProperty("id")
+    private String id;
+
+    /**
+     * account ID
+     */
+    @JsonProperty("accountId")
+    private String accountId;
+
+    /**
      * name
      */
     @JsonProperty("name")
-    @NotBlank(message = "Name 不得為空")
     private String name;
 
     /**
      * phone
      */
     @JsonProperty("phone")
-    @Pattern(regexp = "^[0-9+\\-()\\s]{6,20}$", message = "phone 格式不正確")
-    @NotBlank(message = "phone 不得為空")
     private String phone;
 
     /**

--- a/src/main/java/com/example/petel/repository/UsersRepository.java
+++ b/src/main/java/com/example/petel/repository/UsersRepository.java
@@ -44,4 +44,11 @@ public interface UsersRepository extends JpaRepository<UsersEntity, String> {
      */
     @Query(value = "SELECT ACCOUNT_ID FROM PETEL_USERS WHERE ID = :userId", nativeQuery = true)
     String findByAccountByUserId(@Param("userId") String userId);
+
+    /**
+     * 用 account ID 找資料
+     * @param accountId
+     * @return
+     */
+    Optional<UsersEntity> findByAccountId(String accountId);
 }

--- a/src/main/java/com/example/petel/service/USER002Svc.java
+++ b/src/main/java/com/example/petel/service/USER002Svc.java
@@ -1,0 +1,15 @@
+package com.example.petel.service;
+
+import com.example.petel.dto.Req;
+import com.example.petel.dto.Res;
+import com.example.petel.dto.USER002Tranrq;
+import com.example.petel.dto.USER002Tranrs;
+import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.InsertFailException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+public interface USER002Svc {
+
+    Res<USER002Tranrs> updateUser(String accountId, Req<USER002Tranrq> req)
+            throws DataNotFoundException, JsonMappingException, InsertFailException;
+}

--- a/src/main/java/com/example/petel/service/impl/USER001SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/USER001SvcImpl.java
@@ -23,8 +23,8 @@ public class USER001SvcImpl implements USER001Svc {
     /** ObjectMapper */
     private final ObjectMapper objectMapper;
 
-    @Transactional
     @Override
+    @Transactional(rollbackOn = Exception.class)
     public Res<USER001Tranrs> createUser(String accountId, Req<USER001Tranrq> req)
             throws InsertFailException {
         log.info("---- [USER-001] 新增會員資訊 ----");

--- a/src/main/java/com/example/petel/service/impl/USER002SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/USER002SvcImpl.java
@@ -1,0 +1,58 @@
+package com.example.petel.service.impl;
+
+import com.example.petel.dto.*;
+import com.example.petel.entity.UsersEntity;
+import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.InsertFailException;
+import com.example.petel.model.ReturnCodeAndDescEnum;
+import com.example.petel.repository.UsersRepository;
+import com.example.petel.service.USER002Svc;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class USER002SvcImpl implements USER002Svc {
+
+    /** UsersRepository */
+    private final UsersRepository usersRepo;
+    /** ObjectMapper */
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional(rollbackOn = Exception.class)
+    public Res<USER002Tranrs> updateUser(String accountId, Req<USER002Tranrq> req)
+            throws DataNotFoundException, JsonMappingException, InsertFailException {
+        log.info("---- [USER-002] 修改會員資訊 accountId = {} ----", accountId);
+
+        // 取該筆資料
+        UsersEntity user = usersRepo.findByAccountId(accountId)
+                .orElseThrow(() -> new DataNotFoundException("查無此帳號"));
+
+        // 寫入更新資料
+        USER002Tranrq tranrq = req.getTranrq();
+        objectMapper.updateValue(user, tranrq);
+
+        try {
+            usersRepo.save(user);
+            log.info("[USER-002] 修改會員資料成功 userId={}", user.getId());
+        } catch (Exception e) {
+            log.error("[USER-002] 新增會員資料失敗，原因：{}", e.getMessage(), e);
+            throw new InsertFailException("修改會員資訊失敗");
+        }
+
+        USER002Tranrs tranrs = objectMapper.convertValue(user, USER002Tranrs.class);
+
+        return new Res<USER002Tranrs>(
+                new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS),
+                tranrs
+        );
+    }
+}


### PR DESCRIPTION
## Change
- 修改會員資訊 API

## Test
1. run server
2. 把 Security Config 63-72行 註解拿掉
```
.authorizeHttpRequests(auth -> auth
//                                .anyRequest().permitAll() // 開發階段先把所有都打開
                        .requestMatchers(HttpMethod.POST,
                            "/auth/register", "/auth/login",
                            "/auth/forgot-password", "/auth/reset-password",
                            "/auth/verify", "/auth/check").permitAll()
                        .requestMatchers("/auth/me").authenticated()
                        .requestMatchers("/hotels/**").permitAll()
                        .anyRequest()
                        .authenticated()
```
3. 確認 PETEL_USER 表有資料，並且該帳號可以登入
4. call API `POST` http://localhost:8080/auth/login
Body:
```
{
    "MWHEADER": {
        "MSGID": "AUTH-002"
    },
    "TRANRQ": {
        "email": "UserCreate1@example.com",
        "password": "123456",
        "role": "user"
    }
}
```
5. call `POST` http://localhost:8080/user/update
Body:
```
{
    "MWHEADER": {
        "MSGID": "USER-001"
    },
    "TRANRQ": {
        "name": "測試修改",
        "phone": "0944444334"
        // "mediaId": "M000000001"
    }
}
```

## Expected Value
<img width="1126" height="892" alt="image" src="https://github.com/user-attachments/assets/3eeb20ae-4f56-4858-87dc-19819215a882" />

- 未登入
<img width="1126" height="804" alt="image" src="https://github.com/user-attachments/assets/f8a5f53f-d8d4-44b2-a6d0-f5d80ffc5ed2" />
