### PR TITLE
[ADNIN005] booking cancel api

### DIFF
--- a/src/main/java/com/example/petel/controller/AdminController.java
+++ b/src/main/java/com/example/petel/controller/AdminController.java
@@ -4,12 +4,14 @@ import com.example.petel.controller.advice.BaseController;
 import com.example.petel.dto.*;
 import com.example.petel.exception.DataNotFoundException;
 import com.example.petel.exception.InvalidInputException;
+import com.example.petel.exception.UpdateFailException;
 import com.example.petel.service.ADMIN003Svc;
 import com.example.petel.service.ADMIN001Svc;
 import com.example.petel.service.ADMIN006Svc;
 import com.example.petel.service.Admin007Svc;
 import com.example.petel.service.ADMIN002Svc;
 import com.example.petel.service.ADMIN004Svc;
+import com.example.petel.service.ADMIN005Svc;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.Errors;
@@ -38,10 +40,13 @@ public class AdminController extends BaseController {
     /** ADMIN004 Service */
     private final ADMIN004Svc admin004Svc;
 
+    /** ADMIN005 Service */
+    private final ADMIN005Svc admin005Svc;
+
     /** Admin007 Service */
     private final Admin007Svc admin007Svc;
 
- 
+
 
     /**
      * Admin-001: 查詢所有旅館列表
@@ -138,9 +143,26 @@ public class AdminController extends BaseController {
      */
     @PostMapping("/bookings/edit")
     public Res<ADMIN004Tranrs> updateOrderNote(@Valid @RequestBody Req<ADMIN004Tranrq> req, Errors errors)
-            throws DataNotFoundException, InvalidInputException, com.example.petel.exception.UpdateFailException, IOException {
+            throws DataNotFoundException, InvalidInputException, UpdateFailException, IOException {
         handleValidForDto(errors);
         return admin004Svc.updateOrderNote(req);
+    }
+
+    /**
+     * Admin-005: 取消訂單
+     *
+     * @param req    Req<ADMIN005Tranrq>
+     * @param errors 驗證錯誤
+     * @return Res<ADMIN005Tranrs>
+     * @throws DataNotFoundException 訂單不存在
+     * @throws InvalidInputException 輸入驗證錯誤
+     * @throws com.example.petel.exception.UpdateFailException 取消失敗
+     */
+    @PostMapping("/bookings/cancel")
+    public Res<ADMIN005Tranrs> cancelOrder(@Valid @RequestBody Req<ADMIN005Tranrq> req, Errors errors)
+            throws DataNotFoundException, InvalidInputException, UpdateFailException {
+        handleValidForDto(errors);
+        return admin005Svc.cancelOrder(req);
     }
 
 

--- a/src/main/java/com/example/petel/controller/advice/WebExceptionHandler.java
+++ b/src/main/java/com/example/petel/controller/advice/WebExceptionHandler.java
@@ -67,7 +67,14 @@ public class WebExceptionHandler {
     @ExceptionHandler(UpdateFailException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public Res<Object> handleUpdateFailException(UpdateFailException ex) {
-        return new Res<>(new ResMwHeader(ReturnCodeAndDescEnum.UPDATE_FAIL), null);
+        ResMwHeader resMwHeader = new ResMwHeader();
+        String message = ex.getMessage();
+        if (message == null || message.isBlank()) {
+            message = ReturnCodeAndDescEnum.UPDATE_FAIL.getDesc();
+        }
+        resMwHeader.setReturnCode(ReturnCodeAndDescEnum.UPDATE_FAIL.getCode());
+        resMwHeader.setReturnDesc(message);
+        return new Res<>(resMwHeader, null);
     }
 
     /**

--- a/src/main/java/com/example/petel/dto/ADMIN005Tranrq.java
+++ b/src/main/java/com/example/petel/dto/ADMIN005Tranrq.java
@@ -1,0 +1,26 @@
+package com.example.petel.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ADMIN005Tranrq implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * 訂單 ID
+     */
+    @NotBlank(message = "訂單 ID 不可為空")
+    @JsonProperty("orderId")
+    private String orderId;
+}

--- a/src/main/java/com/example/petel/dto/ADMIN005Tranrs.java
+++ b/src/main/java/com/example/petel/dto/ADMIN005Tranrs.java
@@ -1,0 +1,42 @@
+package com.example.petel.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ADMIN005Tranrs implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * 訂單 ID
+     */
+    @JsonProperty("orderId")
+    private String orderId;
+
+    /**
+     * 取消後的訂單狀態
+     */
+    @JsonProperty("status")
+    private String status;
+
+    /**
+     * 更新時間
+     */
+    @JsonProperty("updatedAt")
+    private String updatedAt;
+
+    /**
+     * 訊息
+     */
+    @JsonProperty("message")
+    private String message;
+}

--- a/src/main/java/com/example/petel/service/ADMIN005Svc.java
+++ b/src/main/java/com/example/petel/service/ADMIN005Svc.java
@@ -1,0 +1,20 @@
+package com.example.petel.service;
+
+import com.example.petel.dto.ADMIN005Tranrq;
+import com.example.petel.dto.ADMIN005Tranrs;
+import com.example.petel.dto.Req;
+import com.example.petel.dto.Res;
+import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.UpdateFailException;
+
+public interface ADMIN005Svc {
+
+    /**
+     * 取消訂單
+     * @param req Req<ADMIN005Tranrq>
+     * @return Res<ADMIN005Tranrs>
+     * @throws DataNotFoundException 訂單不存在
+     * @throws UpdateFailException 取消失敗
+     */
+    Res<ADMIN005Tranrs> cancelOrder(Req<ADMIN005Tranrq> req) throws DataNotFoundException, UpdateFailException;
+}

--- a/src/main/java/com/example/petel/service/impl/ADMIN005SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/ADMIN005SvcImpl.java
@@ -1,0 +1,87 @@
+package com.example.petel.service.impl;
+
+import com.example.petel.dto.*;
+import com.example.petel.entity.OrdersEntity;
+import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.UpdateFailException;
+import com.example.petel.model.ReturnCodeAndDescEnum;
+import com.example.petel.repository.OrdersRepository;
+import com.example.petel.service.ADMIN005Svc;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ADMIN005SvcImpl implements ADMIN005Svc {
+
+    private final OrdersRepository ordersRepository;
+
+    /**
+     * 取消訂單
+     *
+     * @param req Req<ADMIN005Tranrq>
+     * @return Res<ADMIN005Tranrs>
+     * @throws DataNotFoundException 訂單不存在
+     * @throws UpdateFailException   取消失敗
+     */
+    @Override
+    @Transactional
+    public Res<ADMIN005Tranrs> cancelOrder(Req<ADMIN005Tranrq> req) throws DataNotFoundException, UpdateFailException {
+        log.info("-------- [ADMIN-005] 取消訂單 ---------");
+        ADMIN005Tranrq tranrq = req.getTranrq();
+        String orderId = tranrq.getOrderId();
+
+        log.info("[ADMIN-005] 取消訂單參數: orderId={}", orderId);
+
+        // 查詢訂單是否存在
+        OrdersEntity order = ordersRepository.findById(orderId)
+                .orElseThrow(() -> {
+                    log.warn("[ADMIN-005] 訂單不存在: orderId={}", orderId);
+                    return new DataNotFoundException("訂單不存在");
+                });
+
+        // 檢查訂單是否已經被取消
+        if ("取消訂單".equalsIgnoreCase(order.getStatus())) {
+            log.warn("[ADMIN-005] 訂單已經是取消狀態: orderId={}", orderId);
+            throw new UpdateFailException("訂單已經是取消狀態");
+        }
+
+        try {
+            // 更新訂單狀態為 cancelled
+            order.setStatus("取消訂單");
+            order.setUpdatedAt(LocalDateTime.now());
+
+            // 儲存更新
+            OrdersEntity updatedOrder = ordersRepository.save(order);
+
+            log.info("[ADMIN-005] 訂單取消成功: orderId={}", orderId);
+
+            // 組裝回應
+            ADMIN005Tranrs tranrs = new ADMIN005Tranrs();
+            tranrs.setOrderId(updatedOrder.getId());
+            tranrs.setStatus(updatedOrder.getStatus());
+            tranrs.setMessage("訂單已成功取消");
+
+            // 格式化更新時間為 yyyy-MM-dd
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            tranrs.setUpdatedAt(updatedOrder.getUpdatedAt().format(formatter));
+
+            log.info("[ADMIN-005] 訂單取消完成: orderId={}", tranrs.getOrderId());
+
+            return new Res<>(
+                    new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS),
+                    tranrs
+            );
+        } catch (DataAccessException e) {
+            log.error("[ADMIN-005] 取消訂單失敗: orderId={}, 錯誤訊息: {}", orderId, e.getMessage(), e);
+            throw new UpdateFailException("取消訂單失敗: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Introduction
取消訂單

## Change


## Logic
查詢有沒有此筆訂單，若有即可取消訂單。
若訂單已是取消狀態，會跳更新失敗，RETURMDESC : "訂單已是取消狀態"


## Need
Table: PETEL_ORDERS

## Test
* Call (POST) http://localhost:8080/admin/bookings/cancel
* Type: raw JSON

* 範例資料：(note為非必填)
```
{
    "MWHEADER": {
        "MSGID": "ADMIN-004"
    },
    "TRANRQ": {
        "orderId": "O000000011"
    }
}
```

## Expected Result
編輯成功: 
<img width="1369" height="654" alt="image" src="https://github.com/user-attachments/assets/8fd0ac12-45d5-4852-8621-dc1e88229cb0" />
查無資料: 
<img width="1365" height="479" alt="image" src="https://github.com/user-attachments/assets/0b7e2a9c-faeb-4e58-8696-5846fa62066b" />
訂單已是取消狀態:
<img width="1384" height="643" alt="image" src="https://github.com/user-attachments/assets/3bdcd05a-757d-4b83-a7ea-83dbc1827b5d" />
Order_ID沒有填:
<img width="1369" height="546" alt="image" src="https://github.com/user-attachments/assets/ba8c9c7e-ee09-4a10-9a4b-05df80cd0124" />




## Reference
