### PR TITLE
[BOOK-012] 未付款定時取消訂單 API

### DIFF
--- a/src/main/java/com/example/petel/configuration/UnpaidProcessConfig.java
+++ b/src/main/java/com/example/petel/configuration/UnpaidProcessConfig.java
@@ -1,0 +1,20 @@
+package com.example.petel.configuration;
+
+import com.example.petel.service.BOOK012Svc;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+public class UnpaidProcessConfig {
+
+    @Autowired
+    private BOOK012Svc book012Svc;
+
+    @Scheduled(fixedRate = 60000) // 一分鐘執行一次
+    public void cancelPendingOrders() throws Exception {
+        book012Svc.book012();
+    }
+}

--- a/src/main/java/com/example/petel/repository/OrdersRepository.java
+++ b/src/main/java/com/example/petel/repository/OrdersRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -48,5 +49,21 @@ public interface OrdersRepository extends JpaRepository<OrdersEntity, String> {
         ORDER BY CREATED_AT DESC
     """, nativeQuery = true)
     List<OrdersEntity> findByUserIdOrderByCreatedAtDesc(@Param("userId") String userId);
+
+    /**
+     * 刪除建立訂單後超時未付款的訂單
+     *
+     * @param expiredAt
+     * @return
+     */
+    @Query(value = """
+        select *
+        from PETEL_ORDERS
+        where STATUS = '未付款'
+        and CREATED_AT <= :expiredAt
+        and PAYMENT_ID = 'Y000000002'
+        order by CREATED_AT desc
+    """, nativeQuery = true) // 僅適用於信用卡付款
+    List<OrdersEntity> findByStatusAndCreatedAt(@Param("expiredAt") LocalDateTime expiredAt);
 
 }

--- a/src/main/java/com/example/petel/service/BOOK012Svc.java
+++ b/src/main/java/com/example/petel/service/BOOK012Svc.java
@@ -1,0 +1,5 @@
+package com.example.petel.service;
+
+public interface BOOK012Svc {
+    void book012() throws Exception;
+}

--- a/src/main/java/com/example/petel/service/impl/BOOK012SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/BOOK012SvcImpl.java
@@ -1,0 +1,85 @@
+package com.example.petel.service.impl;
+
+import com.example.petel.entity.OrderItemsEntity;
+import com.example.petel.entity.OrdersEntity;
+import com.example.petel.entity.RoomInventoriesEntity;
+import com.example.petel.entity.RoomsEntity;
+import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.DeleteFailException;
+import com.example.petel.repository.OrderItemsRepository;
+import com.example.petel.repository.OrdersRepository;
+import com.example.petel.repository.RoomInventoriesRepository;
+import com.example.petel.repository.RoomsRepository;
+import com.example.petel.service.BOOK012Svc;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * BOOK-012 未付款定時取消訂單 SvcImpl
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BOOK012SvcImpl implements BOOK012Svc {
+
+    /** OrdersRepository */
+    private final OrdersRepository ordersRepository;
+    /** OrderItemsRepository */
+    private final OrderItemsRepository orderItemsRepository;
+    /** RoomInventoriesRepository */
+    private final RoomInventoriesRepository roomInventoriesRepository;
+    /** RoomsRepository */
+    private final RoomsRepository roomsRepository;
+
+    @Override
+    @Transactional(rollbackOn = Exception.class)
+    public void book012() throws Exception {
+
+        log.info("-------- [BOOK-012] 未付款定時取消訂單 API 啟動 --------");
+
+        for (OrdersEntity pendingOrder : ordersRepository.findByStatusAndCreatedAt(LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()).minusMinutes(10))) {
+
+            String orderId = pendingOrder.getId();
+
+            for (OrderItemsEntity pendingOrderItem : orderItemsRepository.findByOrderId(orderId)) {
+
+                String roomId = pendingOrderItem.getRoomId();
+
+                RoomsEntity roomsEntity = roomsRepository.findById(roomId).orElseThrow(() -> {
+                    log.error("[BOOK-012] 查無房型編號 {} 資料，取消訂單失敗", roomId);
+                    return new DataNotFoundException();
+                });
+
+                RoomInventoriesEntity roomInventoriesEntity = roomInventoriesRepository.findByRoomIdAndStayDate(roomId, pendingOrderItem.getArrivalDate()).orElseThrow(() -> {
+                    log.error("[BOOK-012] 查無庫存資料，取消訂單失敗");
+                    return new DataNotFoundException();
+                });
+
+                int newAvailableQuantity = roomInventoriesEntity.getAvailableQuantity() + pendingOrderItem.getQuantity();
+
+                if (newAvailableQuantity > roomsEntity.getTotalUnits()) {
+                    log.warn("[BOOK-012] 數據邏輯異常，請檢查");
+                    roomInventoriesEntity.setAvailableQuantity(roomsEntity.getTotalUnits());
+                } else {
+                    roomInventoriesEntity.setAvailableQuantity(newAvailableQuantity);
+                }
+                roomInventoriesRepository.save(roomInventoriesEntity);
+            }
+
+            try {
+                orderItemsRepository.deleteByOrderId(orderId); // 先刪子表
+                ordersRepository.delete(pendingOrder); // 再刪父表
+            } catch (Exception e) {
+                log.error("[BOOK-012] 刪除異常");
+                throw new DeleteFailException();
+            }
+        }
+        log.info("-------- [BOOK-012] 未付款定時取消訂單 API 執行完成 --------");
+    }
+}


### PR DESCRIPTION
## Change
有鑑於訂房時尚未付款就會在 DB 建立訂單資料，避免房間庫存被長時間壓縮，增加定時檢測 DB 的 API，每隔一分鐘 run 一次，只要送出訂單後選擇信用卡支付，超過十分鐘 DB 仍未付款，這隻 API 就會直接硬刪除訂單和其詳細資料，並恢復房間庫存的數量。

## Test

前置準備：
DB 需有 PETEL_ORDERS、PETEL_ORDER_ITEMS、PETEL_ROOM_INVENTORIES、PETEL_ROOMS 四張表，並需有資料滿足訂單狀態為"未付款"，且訂單建立十分鐘後並 PAYMENT_ID 為 "Y000000002"才會執行刪除

觀察：
僅後端有反應，不需使用Postman，實際結果請見 DB