### PR TITLE
[Refactor] [BOOK-013] 調整 BOOK-005 API 以及新增 BOOK-013 API：模擬更新訂單付款狀態 (線上刷卡) 

### DIFF
--- a/src/main/java/com/example/petel/controller/BookController.java
+++ b/src/main/java/com/example/petel/controller/BookController.java
@@ -44,6 +44,9 @@ public class BookController extends BaseController {
     /** BOOK009Svc */
     private final BOOK009Svc book009Svc;
 
+    /** BOOK013Svc */
+    private final BOOK013Svc book013Svc;
+
     @PostMapping(value = "/create")
     public Res<BOOK001Tranrs> book001(@AuthenticationPrincipal AccountPrincipal authInfo,
             @Valid @RequestBody Req<BOOK001Tranrq> requestBody, Errors errors) throws InsertFailException, InvalidInputException {
@@ -89,5 +92,10 @@ public class BookController extends BaseController {
     @PostMapping(value = "/credit/notify")
     public String book009(@RequestParam Map<String, Object> requestParam) throws Exception {
         return book009Svc.book009(requestParam);
+    }
+
+    @PostMapping(value = "/simulate/notify")
+    public Res<Object> book013(@Valid @RequestBody Req<BOOK013Tranrq> requestBody, Errors errors) throws Exception {
+        return book013Svc.book013(requestBody);
     }
 }

--- a/src/main/java/com/example/petel/dto/BOOK013Tranrq.java
+++ b/src/main/java/com/example/petel/dto/BOOK013Tranrq.java
@@ -1,0 +1,28 @@
+package com.example.petel.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BOOK013Tranrq implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * orderId
+     */
+    @JsonProperty("order_id")
+    @NotNull(message = "order_id不得為空")
+    @Pattern(regexp = "^O\\d{9}$", message = "請輸入正確格式的order_id")
+    private String orderId;
+}

--- a/src/main/java/com/example/petel/service/BOOK013Svc.java
+++ b/src/main/java/com/example/petel/service/BOOK013Svc.java
@@ -1,0 +1,13 @@
+package com.example.petel.service;
+
+import com.example.petel.dto.BOOK013Tranrq;
+import com.example.petel.dto.Req;
+import com.example.petel.dto.Res;
+import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.InsertFailException;
+import com.example.petel.exception.InvalidPaymentMethodException;
+import com.example.petel.exception.UpdateFailException;
+
+public interface BOOK013Svc {
+    Res<Object> book013(Req<BOOK013Tranrq> requestBody) throws DataNotFoundException, UpdateFailException, InvalidPaymentMethodException, InsertFailException;
+}

--- a/src/main/java/com/example/petel/service/impl/BOOK004SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/BOOK004SvcImpl.java
@@ -99,7 +99,7 @@ public class BOOK004SvcImpl implements BOOK004Svc {
             throw new DeleteFailException();
         }
 
-        ordersEntity.setStatus("取消訂單");
+        ordersEntity.setStatus("已取消");
         ordersEntity.setUpdatedAt(LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
         ordersRepository.save(ordersEntity);
 

--- a/src/main/java/com/example/petel/service/impl/BOOK005SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/BOOK005SvcImpl.java
@@ -2,28 +2,24 @@ package com.example.petel.service.impl;
 
 import com.example.petel.dto.*;
 import com.example.petel.entity.OrdersEntity;
+import com.example.petel.entity.TransactionsEntity;
 import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.InsertFailException;
 import com.example.petel.exception.InvalidPaymentMethodException;
+import com.example.petel.exception.UpdateFailException;
+import com.example.petel.model.IdUtil;
 import com.example.petel.model.ReturnCodeAndDescEnum;
-import com.example.petel.model.TimeUtil;
-import com.example.petel.model.book.CodeUtil;
 import com.example.petel.repository.OrdersRepository;
+import com.example.petel.repository.TransactionsRepository;
 import com.example.petel.service.BOOK005Svc;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.util.UUID;
 
 /**
  * BOOK-005 組合付款參數 (現場付款) SvcImpl
@@ -33,26 +29,28 @@ import java.time.ZonedDateTime;
 @RequiredArgsConstructor
 public class BOOK005SvcImpl implements BOOK005Svc {
 
+    /** TransactionsRepository */
+    private final TransactionsRepository transactionsRepository;
     /** OrdersRepository */
     private final OrdersRepository ordersRepository;
     /** PAYMENT_ID */
     private static final String PAYMENT_ID = "Y000000001";
-    /** MERCHANT_ID */
-    @Value("${ecpay.merchantId}")
-    private String MERCHANT_ID;
-    /** HASH_KEY */
-    @Value("${ecpay.hashKey}")
-    private String HASH_KEY;
-    /** HASH_IV */
-    @Value("${ecpay.hashIv}")
-    private String HASH_IV;
-    /** RETURN_URL */
-    @Value("${ecpay.authorize.returnUrl}")
-    private String RETURN_URL;
-    /** ITEM_NAME */
-    private static final String ITEM_NAME = "PETEL room(s)";
-    /** RestTemplate */
-    private final RestTemplate restTemplate = new RestTemplate();
+//    /** MERCHANT_ID */
+//    @Value("${ecpay.merchantId}")
+//    private String MERCHANT_ID;
+//    /** HASH_KEY */
+//    @Value("${ecpay.hashKey}")
+//    private String HASH_KEY;
+//    /** HASH_IV */
+//    @Value("${ecpay.hashIv}")
+//    private String HASH_IV;
+//    /** RETURN_URL */
+//    @Value("${ecpay.authorize.returnUrl}")
+//    private String RETURN_URL;
+//    /** ITEM_NAME */
+//    private static final String ITEM_NAME = "PETEL room(s)";
+//    /** RestTemplate */
+//    private final RestTemplate restTemplate = new RestTemplate();
 
     /**
      * 組合付款參數 for 現場付款：信用卡預先授權
@@ -74,57 +72,92 @@ public class BOOK005SvcImpl implements BOOK005Svc {
         });
 
         if (!PAYMENT_ID.equals(ordersEntity.getPaymentId())) {
-            log.error("[BOOK-005] 您的付款方式不適用這隻 API");
+            log.warn("[BOOK-005] 您的付款方式不適用這隻 API");
             throw new InvalidPaymentMethodException();
         }
 
-        JSONObject orderInfoJson = new JSONObject();
-        orderInfoJson.put("MerchantTradeNo", "PETEL" + orderId);
-        orderInfoJson.put("MerchantTradeDate", TimeUtil.getMerchantTradeDate(ordersEntity.getCreatedAt()));
-        orderInfoJson.put("TotalAmount", ordersEntity.getHotelCharges());
-        orderInfoJson.put("ItemName", ITEM_NAME);
-        orderInfoJson.put("TradeDesc", "建立訂單");
-        orderInfoJson.put("ReturnURL", RETURN_URL);
+//        For company use, cancel the following code:
 
-        BOOK005TranrqCardInfo cardInfo = requestBody.getTranrq().getCardInfo();
-        JSONObject cardInfoJson = new JSONObject();
-        cardInfoJson.put("CardNo", cardInfo.getCardNo());
-        cardInfoJson.put("CardValidMM", cardInfo.getCardValidMM());
-        cardInfoJson.put("CardValidYY", cardInfo.getCardValidYY());
-        cardInfoJson.put("CardCVV2", cardInfo.getCardCVV2());
+//        JSONObject orderInfoJson = new JSONObject();
+//        orderInfoJson.put("MerchantTradeNo", "PETEL" + orderId);
+//        orderInfoJson.put("MerchantTradeDate", TimeUtil.getMerchantTradeDate(ordersEntity.getCreatedAt()));
+//        orderInfoJson.put("TotalAmount", ordersEntity.getHotelCharges());
+//        orderInfoJson.put("ItemName", ITEM_NAME);
+//        orderInfoJson.put("TradeDesc", "建立訂單");
+//        orderInfoJson.put("ReturnURL", RETURN_URL);
+//
+//        BOOK005TranrqCardInfo cardInfo = requestBody.getTranrq().getCardInfo();
+//        JSONObject cardInfoJson = new JSONObject();
+//        cardInfoJson.put("CardNo", cardInfo.getCardNo());
+//        cardInfoJson.put("CardValidMM", cardInfo.getCardValidMM());
+//        cardInfoJson.put("CardValidYY", cardInfo.getCardValidYY());
+//        cardInfoJson.put("CardCVV2", cardInfo.getCardCVV2());
+//
+//        BOOK005TranrqConsumerInfo consumerInfo = requestBody.getTranrq().getConsumerInfo();
+//        JSONObject consumerInfoJson = new JSONObject();
+//        consumerInfoJson.put("Phone", consumerInfo.getPhone());
+//        consumerInfoJson.put("Name", consumerInfo.getName());
+//
+//        JSONObject dataJson = new JSONObject();
+//        dataJson.put("MerchantID", MERCHANT_ID);
+//        dataJson.put("OrderInfo", orderInfoJson);
+//        dataJson.put("ChoosePayment", "Credit");
+//        dataJson.put("CardInfo", cardInfoJson);
+//        dataJson.put("ConsumerInfo", consumerInfoJson);
+//
+//        JSONObject rqHeader = new JSONObject();
+//        rqHeader.put("Timestamp", ZonedDateTime.now(ZoneId.of("Asia/Taipei")).toEpochSecond());
+//
+//        JSONObject jsonObject = new JSONObject();
+//        jsonObject.put("MerchantID", MERCHANT_ID);
+//        jsonObject.put("RqHeader", rqHeader);
+//        jsonObject.put("Data", CodeUtil.dataEncrypt(dataJson.toString(), HASH_KEY, HASH_IV));
+//
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_JSON);
+//
+//        HttpEntity<String> request = new HttpEntity<>(jsonObject.toString(), headers);
+//
+//        ResponseEntity<String> response = restTemplate.postForEntity(
+//                "https://ecpayment-stage.ecpay.com.tw/1.0.0/Cashier/BackAuth",
+//                request,
+//                String.class);
 
-        BOOK005TranrqConsumerInfo consumerInfo = requestBody.getTranrq().getConsumerInfo();
-        JSONObject consumerInfoJson = new JSONObject();
-        consumerInfoJson.put("Phone", consumerInfo.getPhone());
-        consumerInfoJson.put("Name", consumerInfo.getName());
+        LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
 
-        JSONObject dataJson = new JSONObject();
-        dataJson.put("MerchantID", MERCHANT_ID);
-        dataJson.put("OrderInfo", orderInfoJson);
-        dataJson.put("ChoosePayment", "Credit");
-        dataJson.put("CardInfo", cardInfoJson);
-        dataJson.put("ConsumerInfo", consumerInfoJson);
+        ordersEntity.setStatus("已授權");
+        ordersEntity.setUpdatedAt(now);
 
-        JSONObject rqHeader = new JSONObject();
-        rqHeader.put("Timestamp", ZonedDateTime.now(ZoneId.of("Asia/Taipei")).toEpochSecond());
+        TransactionsEntity transactionsEntity = new TransactionsEntity();
 
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("MerchantID", MERCHANT_ID);
-        jsonObject.put("RqHeader", rqHeader);
-        jsonObject.put("Data", CodeUtil.dataEncrypt(dataJson.toString(), HASH_KEY, HASH_IV));
+        transactionsEntity.setId(IdUtil.generateTableId("T", transactionsRepository.findMaxId()));
+        transactionsEntity.setOrderId(orderId);
+        transactionsEntity.setPaymentId(PAYMENT_ID);
+        transactionsEntity.setTransactionId("PETEL" + orderId); // 因為無法 call 幕後交易 api
+        transactionsEntity.setFlowType("Pay");
+        transactionsEntity.setHotelCharges(ordersEntity.getHotelCharges()); // 因為無法 call 幕後交易 api
+        transactionsEntity.setCreatedAt(now);
+        transactionsEntity.setStatus("授權成功");
+        transactionsEntity.setIdempotencyKey(UUID.randomUUID().toString());
+        transactionsEntity.setTransactionFee(0);
+        transactionsEntity.setPayTime(now);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        try {
+            ordersRepository.save(ordersEntity);
+        } catch (Exception e) {
+            log.error("[BOOK-005] 更新過程有問題，修改訂單編號為 {} 的訂單資料失敗", orderId);
+            throw new UpdateFailException();
+        }
 
-        HttpEntity<String> request = new HttpEntity<>(jsonObject.toString(), headers);
-
-        ResponseEntity<String> response = restTemplate.postForEntity(
-                "https://ecpayment-stage.ecpay.com.tw/1.0.0/Cashier/BackAuth",
-                request,
-                String.class);
+        try {
+            transactionsRepository.save(transactionsEntity);
+        } catch (Exception e) {
+            log.error("[BOOK-005] 新增資料有問題，新增訂單編號為 {} 的交易資料失敗", orderId);
+            throw new InsertFailException();
+        }
 
         log.info("[BOOK-005] 訂單編號為 {} 的訂單，信用卡幕後授權 API 執行完成", orderId);
 
-        return new Res<>(new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS), new BOOK005Tranrs(response.getBody()));
+        return new Res<>(new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS), new BOOK005Tranrs("OK"));
     }
 }

--- a/src/main/java/com/example/petel/service/impl/BOOK005SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/BOOK005SvcImpl.java
@@ -125,7 +125,7 @@ public class BOOK005SvcImpl implements BOOK005Svc {
 
         LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
 
-        ordersEntity.setStatus("已授權");
+        ordersEntity.setStatus("未付款");
         ordersEntity.setUpdatedAt(now);
 
         TransactionsEntity transactionsEntity = new TransactionsEntity();

--- a/src/main/java/com/example/petel/service/impl/BOOK008SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/BOOK008SvcImpl.java
@@ -94,7 +94,7 @@ public class BOOK008SvcImpl implements BOOK008Svc {
             transactionsEntity.setPayTime(TimeUtil.parseMerchantTradeDate(orderInfoJsonObject.getString("TradeDate")));
             transactionsRepository.save(transactionsEntity);
             OrdersEntity ordersEntity = ordersRepository.findById(orderId).get();
-            ordersEntity.setStatus("已授權");
+            ordersEntity.setStatus("未付款"); // 沒用到但還是改
             ordersEntity.setUpdatedAt(LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault()));
             ordersRepository.save(ordersEntity);
         }

--- a/src/main/java/com/example/petel/service/impl/BOOK013SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/BOOK013SvcImpl.java
@@ -1,0 +1,110 @@
+package com.example.petel.service.impl;
+
+import com.example.petel.dto.BOOK013Tranrq;
+import com.example.petel.dto.Req;
+import com.example.petel.dto.Res;
+import com.example.petel.dto.ResMwHeader;
+import com.example.petel.entity.OrdersEntity;
+import com.example.petel.entity.TransactionsEntity;
+import com.example.petel.exception.DataNotFoundException;
+import com.example.petel.exception.InsertFailException;
+import com.example.petel.exception.InvalidPaymentMethodException;
+import com.example.petel.exception.UpdateFailException;
+import com.example.petel.model.IdUtil;
+import com.example.petel.model.ReturnCodeAndDescEnum;
+import com.example.petel.repository.OrdersRepository;
+import com.example.petel.repository.TransactionsRepository;
+import com.example.petel.service.BOOK013Svc;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.UUID;
+
+/**
+ * BOOK-013 模擬更新訂單付款狀態 (線上刷卡) SvcImpl
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BOOK013SvcImpl implements BOOK013Svc {
+
+    /** TransactionsRepository */
+    private final TransactionsRepository transactionsRepository;
+    /** OrdersRepository */
+    private final OrdersRepository ordersRepository;
+    /** PAYMENT_ID */
+    private static final String PAYMENT_ID = "Y000000002";
+
+    /**
+     * 模擬更新訂單付款狀態 (線上刷卡)
+     *
+     * @param requestBody Req<BOOK013Tranrq>
+     * @return Res<Object>
+     * @throws DataNotFoundException 查無資料
+     * @throws UpdateFailException 修改失敗
+     * @throws InvalidPaymentMethodException 付款方式異常
+     * @throws InvalidPaymentMethodException 新增失敗
+     */
+    @Override
+    @Transactional(rollbackOn = Exception.class)
+    public Res<Object> book013(Req<BOOK013Tranrq> requestBody) throws DataNotFoundException, UpdateFailException, InvalidPaymentMethodException, InsertFailException {
+
+        log.info("-------- [BOOK-013] 模擬更新訂單付款狀態 (線上刷卡) API 啟動 --------");
+
+        String orderId = requestBody.getTranrq().getOrderId();
+
+        OrdersEntity ordersEntity = ordersRepository.findById(orderId)
+                .orElseThrow(() -> {
+                    log.error("[BOOK-013] 查無訂單編號為 {} 的資料", orderId);
+                    return new DataNotFoundException();
+                });
+
+        if (!PAYMENT_ID.equals(ordersEntity.getPaymentId())) {
+            log.warn("[BOOK-013] 您的付款方式不適用這隻 API");
+            throw new InvalidPaymentMethodException();
+        }
+
+        LocalDateTime now = LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
+
+        ordersEntity.setStatus("已付款");
+        ordersEntity.setUpdatedAt(now);
+
+        TransactionsEntity transactionsEntity = new TransactionsEntity();
+
+        transactionsEntity.setId(IdUtil.generateTableId("T", transactionsRepository.findMaxId()));
+        transactionsEntity.setOrderId(orderId);
+        transactionsEntity.setPaymentId(PAYMENT_ID);
+        transactionsEntity.setTransactionId("PETEL" + orderId);
+        transactionsEntity.setFlowType("Pay");
+        transactionsEntity.setHotelCharges(ordersEntity.getHotelCharges());
+        transactionsEntity.setCreatedAt(now);
+        transactionsEntity.setStatus("付款成功");
+        transactionsEntity.setIdempotencyKey(UUID.randomUUID().toString());
+        transactionsEntity.setTransactionFee(0);
+        transactionsEntity.setPayTime(now);
+
+        try {
+            ordersRepository.save(ordersEntity);
+        } catch (Exception e) {
+            log.error("[BOOK-013] 更新過程有問題，修改訂單編號為 {} 的訂單資料失敗", orderId);
+            throw new UpdateFailException();
+        }
+
+        try {
+            transactionsRepository.save(transactionsEntity);
+        } catch (Exception e) {
+            log.error("[BOOK-013] 新增資料有問題，新增訂單編號為 {} 的交易資料失敗", orderId);
+            throw new InsertFailException();
+        }
+
+        log.info("[BOOK-013] 模擬更新訂單付款狀態 (線上刷卡) API 執行完成");
+
+        return new Res<>(new ResMwHeader(ReturnCodeAndDescEnum.SUCCESS), new HashMap<>());
+    }
+}


### PR DESCRIPTION
## Change
### 2025/10/30 15:20：調整更新資料庫狀態的文字敘述

### BOOK-005
* 公司防火牆限制，調整 BOOK-005 API 為不組合相關參數給綠界，也不把資料打進綠界，因為 幕後授權 API介接網址 公司電腦打不進去
* 現在改成打這支 API 同步修改 PETEL_ORDERS table 狀態 & 直接新增資料進 PETEL_TRANSACTIONS，狀態為授權成功

### BOOK-013
* 原本的 BOOK-006 仍保留
* BOOK-013 API 在前端回到完成訂單頁面，就修改 PETEL_ORDERS table 狀態 & 直接新增資料進 PETEL_TRANSACTIONS，狀態為付款成功

## Test
* 使用前端測 https://github.com/JLin056/petel-front/pull/48