### PR TITLE
[refactor][MERCH-004]修改新增房型api,新增成功會同步寫入存取圖片id的資料庫

### DIFF
--- a/src/main/java/com/example/petel/dto/MERCH004Tranrq.java
+++ b/src/main/java/com/example/petel/dto/MERCH004Tranrq.java
@@ -1,6 +1,7 @@
 package com.example.petel.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -66,4 +68,11 @@ public class MERCH004Tranrq implements Serializable {
     @JsonProperty("roomSize")
     @NotBlank(message = "roomSize不得為空")
     private String roomSize;
+
+    /**
+     * 房型圖片列表
+     */
+    @JsonProperty("roomImages")
+    @Valid
+    private List<MERCH004TranrqRoomImage> roomImages;
 }

--- a/src/main/java/com/example/petel/dto/MERCH004TranrqRoomImage.java
+++ b/src/main/java/com/example/petel/dto/MERCH004TranrqRoomImage.java
@@ -1,0 +1,35 @@
+package com.example.petel.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * MERCH004 房型圖片資訊
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MERCH004TranrqRoomImage implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * 媒體ID
+     */
+    @JsonProperty("mediaId")
+    @NotBlank(message = "mediaId不得為空")
+    private String mediaId;
+
+    /**
+     * 排序順序
+     */
+    @JsonProperty("sortOrder")
+    private Integer sortOrder;
+}

--- a/src/main/java/com/example/petel/service/impl/MERCH004SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/MERCH004SvcImpl.java
@@ -2,11 +2,13 @@ package com.example.petel.service.impl;
 
 import com.example.petel.dto.*;
 import com.example.petel.entity.PropertyEntity;
+import com.example.petel.entity.RoomImageEntity;
 import com.example.petel.entity.RoomsEntity;
 import com.example.petel.exception.InsertFailException;
 import com.example.petel.model.IdUtil;
 import com.example.petel.model.ReturnCodeAndDescEnum;
 import com.example.petel.repository.PropertyRepository;
+import com.example.petel.repository.RoomImageRepository;
 import com.example.petel.repository.RoomsRepository;
 import com.example.petel.service.MERCH004Svc;
 import jakarta.transaction.Transactional;
@@ -23,6 +25,11 @@ public class MERCH004SvcImpl implements MERCH004Svc {
      * RoomsRepository
      */
     private final RoomsRepository roomsRepository;
+
+    /**
+     * RoomImageRepository
+     */
+    private final RoomImageRepository roomImageRepository;
 
     /**
      * 新增房型資訊
@@ -42,6 +49,7 @@ public class MERCH004SvcImpl implements MERCH004Svc {
         log.info("[MERCH-004] 生成房型ID:{}", newRoomId);
 
         try {
+            // 1. 新增房型資料到 PETEL_ROOMS
             RoomsEntity roomsEntity = new RoomsEntity();
             roomsEntity.setId(newRoomId);
             roomsEntity.setPropertyId(merch004Tranrq.getPropertyId());
@@ -53,7 +61,24 @@ public class MERCH004SvcImpl implements MERCH004Svc {
             roomsEntity.setRoomSize(merch004Tranrq.getRoomSize());
 
             roomsRepository.save(roomsEntity);
-            log.info("[MERCH-004] 新增成功，新增欄位：{}", merch004Tranrq);
+            log.info("[MERCH-004] 新增房型成功，roomId={}", newRoomId);
+
+            // 2. 新增房型圖片關聯資料到 PETEL_ROOM_IMAGE
+            if (merch004Tranrq.getRoomImages() != null && !merch004Tranrq.getRoomImages().isEmpty()) {
+                for (MERCH004TranrqRoomImage roomImage : merch004Tranrq.getRoomImages()) {
+                    RoomImageEntity roomImageEntity = new RoomImageEntity();
+                    roomImageEntity.setRoomId(newRoomId);
+                    roomImageEntity.setMediaId(roomImage.getMediaId());
+                    roomImageEntity.setSortOrder(roomImage.getSortOrder());
+
+                    roomImageRepository.save(roomImageEntity);
+                    log.info("[MERCH-004] 新增房型圖片關聯：roomId={}, mediaId={}, sortOrder={}",
+                            newRoomId, roomImage.getMediaId(), roomImage.getSortOrder());
+                }
+                log.info("[MERCH-004] 共新增 {} 張房型圖片", merch004Tranrq.getRoomImages().size());
+            } else {
+                log.info("[MERCH-004] 未提供房型圖片");
+            }
 
         } catch (Exception e) {
             log.error("[MERCH-004] 新增房型失敗", e);


### PR DESCRIPTION
## **change**
修改新增房型api,新增成功會同步寫入存取圖片id的資料庫



## **Test**
- Call (POST) http://localhost:8080/merchants/rooms/create
- Use the following json body:
```
{
    "MWHEADER": {
        "MSGID": "MERCH-004"
    },
    "TRANRQ": {
        "propertyId": "P000000006",
        "name": "豪華寵物房",
        "totalUnits": 5,
        "basePrice": 2000,
        "petTypeId": "W001",
        "info": "適合貓咪入住的舒適房型",
        "roomSize": "20坪",
        "roomImages": [
            {
                "mediaId": "M000000017",
                "sortOrder": 1
            },
            {
                "mediaId": "M000000018",
                "sortOrder": 2
            },
            {
                "mediaId": "M000000019",
                "sortOrder": 3
            }
        ]
    }
}
```
## **Expected Result**
<img width="932" height="321" alt="截圖 2025-10-30 下午5 51 41" src="https://github.com/user-attachments/assets/f45eb70a-50d0-48aa-8f6d-07e067fe6061" />

<img width="434" height="452" alt="截圖 2025-10-30 下午5 57 33" src="https://github.com/user-attachments/assets/3174cdc3-80d4-49d0-b861-b36c3812c7ea" />
