### PR TITLE
[Refactor] 客製化查無資料的拋出訊息

### DIFF
--- a/src/main/java/com/example/petel/controller/advice/WebExceptionHandler.java
+++ b/src/main/java/com/example/petel/controller/advice/WebExceptionHandler.java
@@ -47,7 +47,14 @@ public class WebExceptionHandler {
     @ExceptionHandler(DataNotFoundException.class)
     @ResponseStatus(HttpStatus.OK)
     public Res<Object> handleDataNotFoundException(DataNotFoundException ex) {
-        return new Res<>(new ResMwHeader(ReturnCodeAndDescEnum.DATA_NOT_FOUND), null);
+        ResMwHeader resMwHeader = new ResMwHeader();
+        String message = ex.getMessage();
+        if (message == null || message.isBlank()) {
+            message = ReturnCodeAndDescEnum.DATA_NOT_FOUND.getDesc();
+        }
+        resMwHeader.setReturnCode(ReturnCodeAndDescEnum.DATA_NOT_FOUND.getCode());
+        resMwHeader.setReturnDesc(message);
+        return new Res<>(resMwHeader, null);
     }
 
     /**


### PR DESCRIPTION
## Change
客製化查無資料的拋出訊息，讓前端可以直接用後端這裡的客製化拋出消息，不用再另外寫。

## Test
自行找尋查無資料的情境，或用下面例子 (圖一有客製化訊息、圖二無客製化訊息)
<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/b36ecbe4-2241-4038-a510-e03864e34f9f" />
<img width="1919" height="1028" alt="image" src="https://github.com/user-attachments/assets/b2b32c6a-e6cc-43a7-b97c-80c12997cb66" />
