### PR TITLE
[refactor][MEDIA-004] 修改查詢圖片api 

### DIFF
--- a/src/main/java/com/example/petel/dto/MEDIA004TranrsMediaInfo.java
+++ b/src/main/java/com/example/petel/dto/MEDIA004TranrsMediaInfo.java
@@ -67,4 +67,10 @@ public class MEDIA004TranrsMediaInfo implements Serializable {
      */
     @JsonProperty("updatedAt")
     private LocalDateTime updatedAt;
+
+    /**
+     * 排序順序 (僅在透過 propertyId 或 roomId 查詢時有值)
+     */
+    @JsonProperty("sortOrder")
+    private Integer sortOrder;
 }

--- a/src/main/java/com/example/petel/service/impl/MEDIA004SvcImpl.java
+++ b/src/main/java/com/example/petel/service/impl/MEDIA004SvcImpl.java
@@ -10,9 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -39,59 +37,54 @@ public class MEDIA004SvcImpl implements MEDIA004Svc {
         log.info("-------- [MEDIA-004] Base64 圖片查詢 ---------");
 
         MEDIA004Tranrq tranrq = req.getTranrq();
-        List<MediaBase64Entity> mediaEntities = new ArrayList<>();
+        List<MEDIA004TranrsMediaInfo> mediaInfos = new ArrayList<>();
 
         // 1. 優先使用 mediaIds 查詢
         if (tranrq.getMediaIds() != null && !tranrq.getMediaIds().isEmpty()) {
             log.info("[MEDIA-004] 依 mediaIds 查詢，數量：{}", tranrq.getMediaIds().size());
             for (String mediaId : tranrq.getMediaIds()) {
                 Optional<MediaBase64Entity> mediaOptional = mediaBase64Repository.findById(mediaId);
-                mediaOptional.ifPresent(mediaEntities::add);
+                if (mediaOptional.isPresent()) {
+                    mediaInfos.add(convertToMediaInfo(mediaOptional.get(), null));
+                }
             }
 
         } else if (StringUtils.isNotBlank(tranrq.getPropertyId())) {
-            // 2. 使用 propertyId 查詢
+            // 2. 使用 propertyId 查詢 (帶 sortOrder)
             log.info("[MEDIA-004] 依 propertyId 查詢：{}", tranrq.getPropertyId());
-            mediaEntities = queryByPropertyId(tranrq.getPropertyId());
+            mediaInfos = queryByPropertyIdWithSort(tranrq.getPropertyId());
 
         } else if (StringUtils.isNotBlank(tranrq.getRoomId())) {
-            // 3. 使用 roomId 查詢
+            // 3. 使用 roomId 查詢 (帶 sortOrder)
             log.info("[MEDIA-004] 依 roomId 查詢：{}", tranrq.getRoomId());
-            mediaEntities = queryByRoomId(tranrq.getRoomId());
+            mediaInfos = queryByRoomIdWithSort(tranrq.getRoomId());
 
         } else if (StringUtils.isNotBlank(tranrq.getAccountId())) {
             // 4. 使用 accountId 查詢
             log.info("[MEDIA-004] 依 accountId 查詢：{}", tranrq.getAccountId());
-            mediaEntities = queryByAccountId(tranrq.getAccountId());
+            List<MediaBase64Entity> mediaEntities = queryByAccountId(tranrq.getAccountId());
+            mediaInfos = mediaEntities.stream()
+                    .map(entity -> convertToMediaInfo(entity, null))
+                    .collect(Collectors.toList());
 
         } else if (tranrq.getBucket() != null && !tranrq.getBucket().trim().isEmpty()) {
             // 5. 使用 bucket 查詢
             log.info("[MEDIA-004] 依 bucket 查詢：{}", tranrq.getBucket());
-            mediaEntities = mediaBase64Repository.findByBucket(tranrq.getBucket());
+            List<MediaBase64Entity> mediaEntities = mediaBase64Repository.findByBucket(tranrq.getBucket());
+            mediaInfos = mediaEntities.stream()
+                    .map(entity -> convertToMediaInfo(entity, null))
+                    .collect(Collectors.toList());
 
         } else {
             // 6. 查詢全部
             log.info("[MEDIA-004] 查詢全部媒體");
-            mediaEntities = mediaBase64Repository.findAll();
+            List<MediaBase64Entity> mediaEntities = mediaBase64Repository.findAll();
+            mediaInfos = mediaEntities.stream()
+                    .map(entity -> convertToMediaInfo(entity, null))
+                    .collect(Collectors.toList());
         }
 
-        log.info("[MEDIA-004] 查詢到 {} 筆媒體", mediaEntities.size());
-
-        // 轉換為 DTO
-        List<MEDIA004TranrsMediaInfo> mediaInfos = new ArrayList<>();
-        for (MediaBase64Entity entity : mediaEntities) {
-            MEDIA004TranrsMediaInfo mediaInfo = new MEDIA004TranrsMediaInfo();
-            mediaInfo.setMediaId(entity.getId());
-            mediaInfo.setBase64Data(entity.getBase64Data());
-            mediaInfo.setBucket(entity.getBucket());
-            mediaInfo.setFileName(entity.getFileName());
-            mediaInfo.setSizeBytes(entity.getSizeBytes());
-            mediaInfo.setMimeType(entity.getMimeType());
-            mediaInfo.setCreatedAt(entity.getCreatedAt());
-            mediaInfo.setUpdatedAt(entity.getUpdatedAt());
-
-            mediaInfos.add(mediaInfo);
-        }
+        log.info("[MEDIA-004] 查詢到 {} 筆媒體", mediaInfos.size());
 
         // 建立回應
         MEDIA004Tranrs tranrs = new MEDIA004Tranrs(
@@ -106,7 +99,71 @@ public class MEDIA004SvcImpl implements MEDIA004Svc {
     }
 
     /**
-     * 根據 propertyId 查詢圖片
+     * 轉換 MediaBase64Entity 為 MEDIA004TranrsMediaInfo
+     */
+    private MEDIA004TranrsMediaInfo convertToMediaInfo(MediaBase64Entity entity, Integer sortOrder) {
+        MEDIA004TranrsMediaInfo mediaInfo = new MEDIA004TranrsMediaInfo();
+        mediaInfo.setMediaId(entity.getId());
+        mediaInfo.setBase64Data(entity.getBase64Data());
+        mediaInfo.setBucket(entity.getBucket());
+        mediaInfo.setFileName(entity.getFileName());
+        mediaInfo.setSizeBytes(entity.getSizeBytes());
+        mediaInfo.setMimeType(entity.getMimeType());
+        mediaInfo.setCreatedAt(entity.getCreatedAt());
+        mediaInfo.setUpdatedAt(entity.getUpdatedAt());
+        mediaInfo.setSortOrder(sortOrder);
+        return mediaInfo;
+    }
+
+    /**
+     * 根據 propertyId 查詢圖片 (帶 sortOrder)
+     */
+    private List<MEDIA004TranrsMediaInfo> queryByPropertyIdWithSort(String propertyId) {
+        try {
+            // 1. 從 PETEL_PROPERTY_IMAGE 查詢 mediaId 和 sortOrder
+            List<PropertyImageEntity> propertyImages = propertyImageRepository.findByPropertyId(propertyId);
+
+            if (propertyImages.isEmpty()) {
+                log.warn("[MEDIA-004] propertyId={} 查無圖片", propertyId);
+                return new ArrayList<>();
+            }
+
+            // 2. 收集所有 mediaId
+            List<String> mediaIds = propertyImages.stream()
+                    .map(PropertyImageEntity::getMediaId)
+                    .collect(Collectors.toList());
+
+            // 3. 從 PETEL_MEDIA_BASE64 查詢圖片資料
+            List<MediaBase64Entity> mediaEntities = mediaBase64Repository.findAllById(mediaIds);
+
+            // 4. 建立 mediaId -> MediaBase64Entity 的 Map
+            Map<String, MediaBase64Entity> mediaMap = mediaEntities.stream()
+                    .collect(Collectors.toMap(MediaBase64Entity::getId, entity -> entity));
+
+            // 5. 組裝結果，包含 sortOrder
+            List<MEDIA004TranrsMediaInfo> result = new ArrayList<>();
+            for (PropertyImageEntity propertyImage : propertyImages) {
+                MediaBase64Entity media = mediaMap.get(propertyImage.getMediaId());
+                if (media != null) {
+                    result.add(convertToMediaInfo(media, propertyImage.getSortOrder()));
+                }
+            }
+
+            // 6. 按 sortOrder 排序
+            result.sort(Comparator.comparing(
+                    MEDIA004TranrsMediaInfo::getSortOrder,
+                    Comparator.nullsLast(Comparator.naturalOrder())
+            ));
+
+            return result;
+        } catch (Exception e) {
+            log.error("[MEDIA-004] 依 propertyId 查詢失敗", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * 根據 propertyId 查詢圖片 (舊版，保留向後兼容)
      */
     private List<MediaBase64Entity> queryByPropertyId(String propertyId) {
         try {
@@ -132,7 +189,54 @@ public class MEDIA004SvcImpl implements MEDIA004Svc {
     }
 
     /**
-     * 根據 roomId 查詢圖片
+     * 根據 roomId 查詢圖片 (帶 sortOrder)
+     */
+    private List<MEDIA004TranrsMediaInfo> queryByRoomIdWithSort(String roomId) {
+        try {
+            // 1. 從 PETEL_ROOM_IMAGE 查詢 mediaId 和 sortOrder
+            List<RoomImageEntity> roomImages = roomImageRepository.findByRoomId(roomId);
+
+            if (roomImages.isEmpty()) {
+                log.warn("[MEDIA-004] roomId={} 查無圖片", roomId);
+                return new ArrayList<>();
+            }
+
+            // 2. 收集所有 mediaId
+            List<String> mediaIds = roomImages.stream()
+                    .map(RoomImageEntity::getMediaId)
+                    .collect(Collectors.toList());
+
+            // 3. 從 PETEL_MEDIA_BASE64 查詢圖片資料
+            List<MediaBase64Entity> mediaEntities = mediaBase64Repository.findAllById(mediaIds);
+
+            // 4. 建立 mediaId -> MediaBase64Entity 的 Map
+            Map<String, MediaBase64Entity> mediaMap = mediaEntities.stream()
+                    .collect(Collectors.toMap(MediaBase64Entity::getId, entity -> entity));
+
+            // 5. 組裝結果，包含 sortOrder
+            List<MEDIA004TranrsMediaInfo> result = new ArrayList<>();
+            for (RoomImageEntity roomImage : roomImages) {
+                MediaBase64Entity media = mediaMap.get(roomImage.getMediaId());
+                if (media != null) {
+                    result.add(convertToMediaInfo(media, roomImage.getSortOrder()));
+                }
+            }
+
+            // 6. 按 sortOrder 排序
+            result.sort(Comparator.comparing(
+                    MEDIA004TranrsMediaInfo::getSortOrder,
+                    Comparator.nullsLast(Comparator.naturalOrder())
+            ));
+
+            return result;
+        } catch (Exception e) {
+            log.error("[MEDIA-004] 依 roomId 查詢失敗", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * 根據 roomId 查詢圖片 (舊版，保留向後兼容)
      */
     private List<MediaBase64Entity> queryByRoomId(String roomId) {
         try {


### PR DESCRIPTION
## Change
- 修改查詢圖片api，加上可回傳sortOrder

## Test
* Call (POST) : http://localhost:8080/medias/query/base64
* Use the following json body:
--透過mediaId查詢--
```
{
    "MWHEADER": {
        "MSGID": "MEDIA-004"
    },
    "TRANRQ": {
        // "propertyId": "P000000001"
        "roomId":"R000000001"
        // "accountId":"A00001"
        // "mediaIds": ["M000000007", "M000000009"]
        // "bucket": "Property_Image"
    }
}
```
## Expected Result:
<img width="857" height="342" alt="截圖 2025-11-03 晚上7 09 35" src="https://github.com/user-attachments/assets/53f43b85-0888-4ca0-a55f-9691a4400509" />

加上可回傳sortOrder